### PR TITLE
Remove OSM Attribution from Footer

### DIFF
--- a/components/custom/footer.tsx
+++ b/components/custom/footer.tsx
@@ -21,15 +21,6 @@ export function Footer({ className }: { className?: string }) {
             rel="noopener noreferrer"
           >
             GeoNames
-          </a>{' '}
-          and{' '}
-          <a
-            className="underline"
-            href="https://www.openstreetmap.org/copyright"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            OpenStreetMap
           </a>
           .
         </p>


### PR DESCRIPTION
Remove OSM attribution from Footer as we're no longer using their data or services (due to the removal of the reverse geocoding feature). 